### PR TITLE
Update Assertj version in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.platform.version>1.9.2</junit.platform.version>
         <junit.version>5.9.2</junit.version>
+        <asserj.version>3.24.2</asserj.version>
         <mockito.version>5.4.0</mockito.version>
         <pitest.version>1.14.2</pitest.version>
         <pitest.junit5.version>1.2.0</pitest.junit5.version>
@@ -45,7 +46,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.21.0</version>
+            <version>${asserj.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Added Assertj version 3.24.2 to the properties section and updated the version tag of the Assertj dependency in pom.xml. This is to keep our testing library up-to-date and to reduce hard-coded version numbers in the dependencies section, making future updates easier.