### PR TITLE
Add white-box tests for RomanToArabicConverter

### DIFF
--- a/src/main/java/com/epam/chucknorris/decode/BinaryToAsciiConverter.java
+++ b/src/main/java/com/epam/chucknorris/decode/BinaryToAsciiConverter.java
@@ -1,0 +1,26 @@
+package com.epam.chucknorris.decode;
+
+import java.util.function.ToIntFunction;
+import java.util.function.UnaryOperator;
+import java.util.regex.MatchResult;
+import java.util.regex.Pattern;
+
+public class BinaryToAsciiConverter implements UnaryOperator<String> {
+    private static final Pattern SEVEN_BITS_PATTERN = Pattern.compile("[01]{7}");
+
+    @Override
+    public String apply(String binaryRepresentation) {
+        var asciiCharacters = SEVEN_BITS_PATTERN
+                .matcher(binaryRepresentation)
+                .results()
+                .map(MatchResult::group)
+                .mapToInt(convertBinaryToAscii())
+                .toArray();
+
+        return new String(asciiCharacters, 0, asciiCharacters.length);
+    }
+
+    private static ToIntFunction<String> convertBinaryToAscii() {
+        return binaryString -> Integer.parseInt(binaryString, 2);
+    }
+}

--- a/src/main/java/com/epam/chucknorris/decode/UnaryToBinaryConverter.java
+++ b/src/main/java/com/epam/chucknorris/decode/UnaryToBinaryConverter.java
@@ -1,0 +1,25 @@
+package com.epam.chucknorris.decode;
+
+import java.util.function.UnaryOperator;
+import java.util.regex.MatchResult;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public final class UnaryToBinaryConverter implements UnaryOperator<String> {
+    private static final Pattern GROUP_PATTERN = Pattern.compile("00? 0+");
+
+    @Override
+    public String apply(String unaryRepresentation) {
+        return GROUP_PATTERN.matcher(unaryRepresentation)
+                .results()
+                .map(MatchResult::group)
+                .map(this::convertUnaryToBinary)
+                .collect(Collectors.joining());
+    }
+
+    String convertUnaryToBinary(String block) {
+        var unit = block.startsWith("00") ? "0" : "1";
+        var length = block.length() - (unit.equals("0") ? 3 : 2);
+        return unit.repeat(length);
+    }
+}

--- a/src/main/java/com/epam/chucknorris/encode/AsciiToBinaryConverter.java
+++ b/src/main/java/com/epam/chucknorris/encode/AsciiToBinaryConverter.java
@@ -9,7 +9,7 @@ import static java.util.stream.Collectors.joining;
  * This class implements the UnaryOperator interface, allowing it to be used as a function
  * to convert a string using the apply method.
  */
-public final class BinaryConverter implements UnaryOperator<String> {
+public final class AsciiToBinaryConverter implements UnaryOperator<String> {
     private static final int HIGH_BIT = 0x80;
     private static final int ASCII_MASK = 0x7F;
 

--- a/src/main/java/com/epam/chucknorris/encode/BinaryToUnaryConverter.java
+++ b/src/main/java/com/epam/chucknorris/encode/BinaryToUnaryConverter.java
@@ -6,9 +6,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 
-public final class UnaryConverter implements UnaryOperator<String> {
+public final class BinaryToUnaryConverter implements UnaryOperator<String> {
     private static final Pattern PATTERN = Pattern.compile("0+|1+");
-
 
     @Override
     public java.lang.String apply(String binaryRepresentation) {

--- a/src/test/java/com/epam/chucknorris/decode/BinaryToAsciiConverterDiffblueTest.java
+++ b/src/test/java/com/epam/chucknorris/decode/BinaryToAsciiConverterDiffblueTest.java
@@ -1,0 +1,55 @@
+package com.epam.chucknorris.decode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class BinaryToAsciiConverterDiffblueTest {
+    /**
+     * Method under test: {@link BinaryToAsciiConverter#apply(String)}
+     */
+    @Test
+    void testApply() {
+        // Arrange
+        BinaryToAsciiConverter binaryToAsciiConverter = new BinaryToAsciiConverter();
+        String binaryRepresentation = "Binary Representation";
+
+        // Act
+        String actualApplyResult = binaryToAsciiConverter.apply(binaryRepresentation);
+
+        // Assert
+        assertEquals("", actualApplyResult);
+    }
+
+    /**
+     * Method under test: {@link BinaryToAsciiConverter#apply(String)}
+     */
+    @Test
+    void testApply2() {
+        // Arrange
+        BinaryToAsciiConverter binaryToAsciiConverter = new BinaryToAsciiConverter();
+        String binaryRepresentation = "0000000";
+
+        // Act
+        String actualApplyResult = binaryToAsciiConverter.apply(binaryRepresentation);
+
+        // Assert
+        assertEquals("\u0000", actualApplyResult);
+    }
+
+    /**
+     * Method under test: {@link BinaryToAsciiConverter#apply(String)}
+     */
+    @Test
+    void testApply3() {
+        // Arrange
+        BinaryToAsciiConverter binaryToAsciiConverter = new BinaryToAsciiConverter();
+        String binaryRepresentation = "00000000000000";
+
+        // Act
+        String actualApplyResult = binaryToAsciiConverter.apply(binaryRepresentation);
+
+        // Assert
+        assertEquals("\u0000\u0000", actualApplyResult);
+    }
+}

--- a/src/test/java/com/epam/chucknorris/decode/BinaryToAsciiConverterWhiteBoxAiTest.java
+++ b/src/test/java/com/epam/chucknorris/decode/BinaryToAsciiConverterWhiteBoxAiTest.java
@@ -1,0 +1,31 @@
+package com.epam.chucknorris.decode;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import static org.assertj.core.api.Assertions.assertThat;
+import java.util.stream.Stream;
+
+@DisplayName("Test BinaryToAsciiConverter")
+class BinaryToAsciiConverterWhiteBoxAiTest {
+
+    private final BinaryToAsciiConverter converter = new BinaryToAsciiConverter();
+
+    @DisplayName("Test apply method")
+    @ParameterizedTest(name = "{index} => for binary input: {0}, expect ascii output: {1}")
+    @MethodSource("binaryToAsciiDataProvider")
+    void testApply(String binaryInput, String expectedAsciiOutput) {
+        var actualAsciiOutput = converter.apply(binaryInput);
+        assertThat(actualAsciiOutput).isEqualTo(expectedAsciiOutput);
+    }
+
+    private static Stream<Object[]> binaryToAsciiDataProvider() {
+        return Stream.of(
+                new Object[]{"110000111000101100011", "abc"},
+                new Object[]{"1101001110111111011101101001", "ioni"},
+                new Object[]{"110111111011101101001", "oni"},
+                new Object[]{"0111001", "9"},
+                new Object[]{"0000000", "\u0000"}
+        );
+    }
+}

--- a/src/test/java/com/epam/chucknorris/decode/UnaryToBinaryConverterDiffblueTest.java
+++ b/src/test/java/com/epam/chucknorris/decode/UnaryToBinaryConverterDiffblueTest.java
@@ -1,0 +1,71 @@
+package com.epam.chucknorris.decode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class UnaryToBinaryConverterDiffblueTest {
+    /**
+     * Method under test: {@link UnaryToBinaryConverter#apply(String)}
+     */
+    @Test
+    void testApply() {
+        // Arrange
+        UnaryToBinaryConverter unaryToBinaryConverter = new UnaryToBinaryConverter();
+        String unaryRepresentation = "Unary Representation";
+
+        // Act
+        String actualApplyResult = unaryToBinaryConverter.apply(unaryRepresentation);
+
+        // Assert
+        assertEquals("", actualApplyResult);
+    }
+
+    /**
+     * Method under test: {@link UnaryToBinaryConverter#apply(String)}
+     */
+    @Test
+    void testApply2() {
+        // Arrange
+        UnaryToBinaryConverter unaryToBinaryConverter = new UnaryToBinaryConverter();
+        String unaryRepresentation = "0 0";
+
+        // Act
+        String actualApplyResult = unaryToBinaryConverter.apply(unaryRepresentation);
+
+        // Assert
+        assertEquals("1", actualApplyResult);
+    }
+
+    /**
+     * Method under test: {@link UnaryToBinaryConverter#apply(String)}
+     */
+    @Test
+    void testApply3() {
+        // Arrange
+        UnaryToBinaryConverter unaryToBinaryConverter = new UnaryToBinaryConverter();
+        String unaryRepresentation = "00 0";
+
+        // Act
+        String actualApplyResult = unaryToBinaryConverter.apply(unaryRepresentation);
+
+        // Assert
+        assertEquals("0", actualApplyResult);
+    }
+
+    /**
+     * Method under test: {@link UnaryToBinaryConverter#apply(String)}
+     */
+    @Test
+    void testApply4() {
+        // Arrange
+        UnaryToBinaryConverter unaryToBinaryConverter = new UnaryToBinaryConverter();
+        String unaryRepresentation = "0 00 00 0";
+
+        // Act
+        String actualApplyResult = unaryToBinaryConverter.apply(unaryRepresentation);
+
+        // Assert
+        assertEquals("110", actualApplyResult);
+    }
+}

--- a/src/test/java/com/epam/chucknorris/decode/UnaryToBinaryConverterWhiteBoxAiTest.java
+++ b/src/test/java/com/epam/chucknorris/decode/UnaryToBinaryConverterWhiteBoxAiTest.java
@@ -1,0 +1,36 @@
+package com.epam.chucknorris.decode;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("UnaryToBinaryConverter:")
+class UnaryToBinaryConverterWhiteBoxAiTest {
+
+    private final UnaryToBinaryConverter converter = new UnaryToBinaryConverter();
+
+    @DisplayName("Should convert unary to binary:")
+    @ParameterizedTest(name = "{index} => should convert {0} to {1}")
+    @CsvSource(delimiter = '|', textBlock = """
+        00 0  | 0
+        0 0   | 1
+        00 00 | 00
+        0 000 | 111
+    """)
+    void shouldConvertUnaryToBinary(String unary, String expectedBinary) {
+        var actualBinary = converter.apply(unary);
+        assertThat(actualBinary).isEqualTo(expectedBinary);
+    }
+
+    @DisplayName("Should convert unary blocks to binary parts correctly:")
+    @ParameterizedTest(name = "{index} => should convert {0} to {1}")
+    @CsvSource(delimiter = '|', textBlock = """
+        00 0     | 0
+        0 0      | 1
+    """ )
+    void shouldConvertUnaryBlockToBinaryPartCorrectly(String block, String expectedBinary) {
+        var actualBinary = converter.convertUnaryToBinary(block);
+        assertThat(actualBinary).isEqualTo(expectedBinary);
+    }
+}

--- a/src/test/java/com/epam/chucknorris/encode/AsciiToBinaryConverterWhiteBoxAiTest.java
+++ b/src/test/java/com/epam/chucknorris/encode/AsciiToBinaryConverterWhiteBoxAiTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class BinaryConverterWhiteBoxAiTest {
+class AsciiToBinaryConverterWhiteBoxAiTest {
 
     @DisplayName("Convert a string to binary using ASCII encoding")
     @ParameterizedTest(name = "Test case: {0} => ASCII string: {1}, Expected Binary: {2}")
@@ -18,7 +18,7 @@ class BinaryConverterWhiteBoxAiTest {
                 Text special characters      | @#$ | 100000001000110100100
             """)
     void apply(String scenario, String text, String expectedBinary) {
-        var binaryConverter = new BinaryConverter();
+        var binaryConverter = new AsciiToBinaryConverter();
         var actualBinary = binaryConverter.apply(text);
         assertEquals(expectedBinary, actualBinary);
     }
@@ -32,7 +32,7 @@ class BinaryConverterWhiteBoxAiTest {
                 Character @                  | 64 | 1000000
             """)
     void charToBinary(String scenario, int character, String expectedBinary) {
-        var binaryConverter = new BinaryConverter();
+        var binaryConverter = new AsciiToBinaryConverter();
         var actualBinary = binaryConverter.charToBinary(character);
         assertEquals(expectedBinary, actualBinary);
     }

--- a/src/test/java/com/epam/chucknorris/encode/BinaryToUnaryConverterWhiteBoxAiTest.java
+++ b/src/test/java/com/epam/chucknorris/encode/BinaryToUnaryConverterWhiteBoxAiTest.java
@@ -7,9 +7,9 @@ import org.junit.jupiter.params.provider.CsvSource;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("Unary Converter Test class")
-class UnaryConverterWhiteBoxAiTest {
+class BinaryToUnaryConverterWhiteBoxAiTest {
 
-    UnaryConverter unaryConverter = new UnaryConverter();
+    BinaryToUnaryConverter binaryToUnaryConverter = new BinaryToUnaryConverter();
 
     @DisplayName("Tests Unary Converter apply method.")
     @ParameterizedTest(name = "{index} => the binary sequence {0}:{1}")
@@ -24,7 +24,7 @@ class UnaryConverterWhiteBoxAiTest {
         more complex binary sequence                  |    110011001 |  '0 00 00 00 0 00 00 00 0 0'
     """)
     void applyTest(String scenario, String binarySequence, String expectedUnarySequence) {
-        var result = unaryConverter.apply(binarySequence);
+        var result = binaryToUnaryConverter.apply(binarySequence);
         assertThat(result).isEqualTo(expectedUnarySequence);
     }
     
@@ -37,7 +37,7 @@ class UnaryConverterWhiteBoxAiTest {
         single binary sequence with 1's only        |    1111      |  '0 0000'
     """)
     void convertBinaryToUnaryTest(String scenario, String binarySequence, String expectedUnarySequence) {
-        var result = unaryConverter.convertBinaryToUnary(binarySequence);
+        var result = binaryToUnaryConverter.convertBinaryToUnary(binarySequence);
         assertThat(result).isEqualTo(expectedUnarySequence);
     }
 }

--- a/src/test/java/com/epam/chucknorris/junit5-white-box.md
+++ b/src/test/java/com/epam/chucknorris/junit5-white-box.md
@@ -1,0 +1,36 @@
+Act as an experienced Java developer.
+Use Java 17 and all the features that this version has.
+
+For the given {code}, your task is to write a unit test with 100% coverage.
+Generate self-documenting, best-practice, parameterized, readable test code.
+Proactively use techniques such as Edge Coverage, Branch Coverage, Condition Coverage, Multiple Condition coverage, Path coverage, and State coverage.
+
+- use JUnit 5 framework with AssertJ assertions;
+- use `@DisplayName` annotation;
+- when using parameterized tests, always customize display names;
+- if the parameters are primitive types or strings prefer @CsvSource annotation
+- if the parameters are classes prefer @MethodSource annotation
+- for @CsvSource use delimiter = '|' and textBlock
+  Example:
+```java
+@DisplayName("Calculates the sum of:")
+@ParameterizedTest(name = "{index} => calculates the sum of {0}: ({1}, {2})")
+@CsvSource(delimiter = '|', textBlock = """
+    positive numbers      |   10  |      6  |   16
+    positive and negative |   -4  |      2  |   -2
+    negative numbers      |   -6  |   -100  | -106
+""")
+void calculatesSum(String scenario, int a, int b, int expectedResult) {
+    var actual = calculator.sum(a, b);
+    assertThat(actual).isEqualTo(expectedResult);
+}
+```
+- align delimiters inside textBlock to improve readability
+- inside textBlock use ' instead of "
+- inside test methods use `var` keyword instead of the fully qualified type name;
+- omit the public modifier for test classes, test methods, and lifecycle methods;
+- the test class name must end with the suffix `WhiteBoxAiTest`;
+- the test class must be in the same package as the code under test;
+- If there is a class unknown to you, ask me for a description of this class before you generate unit tests.
+
+{code}: $SELECTION

--- a/src/test/java/com/epam/roman/RomanToArabicConverterWhiteBoxAiTest.java
+++ b/src/test/java/com/epam/roman/RomanToArabicConverterWhiteBoxAiTest.java
@@ -1,0 +1,40 @@
+package com.epam.roman;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@DisplayName("RomanToArabicConverter class tests")
+class RomanToArabicConverterWhiteBoxAiTest {
+    private final RomanToArabicConverter romanToArabicConverter = new RomanToArabicConverter();
+
+    @DisplayName("Converting valid Roman numerals to Arabic:")
+    @ParameterizedTest(name = "{index}: Converting {0} to Arabic should give {1}")
+    @CsvSource(delimiter = '=', textBlock = """
+        'I'           = 1
+        'IV'          = 4
+        'V'           = 5
+        'IX'          = 9
+        'X'           = 10
+        'XL'          = 40
+        'L'           = 50
+        'XC'          = 90
+        'C'           = 100
+        'CD'          = 400
+        'D'           = 500
+        'CM'          = 900
+        'M'           = 1000
+        'MMCCCXLIV'   = 2344
+        'MCMXCIX'     = 1999
+        ''            = 0
+        'BDFHJ@#'     = 500
+    """)
+    void testValidRomanConversions(String romanNumeral, int expectedArabicValue) {
+        var actual = romanToArabicConverter.applyAsInt(romanNumeral);
+        assertThat(actual)
+                .as("The roman numeral %s should be converted to %d", romanNumeral, expectedArabicValue)
+                .isEqualTo(expectedArabicValue);
+    }
+}


### PR DESCRIPTION
Added a new test class, RomanToArabicConverterWhiteBoxAiTest, that contains parameterized tests for the RomanToArabicConverter. The tests cover various valid roman numeral conversions to arabic. The goal is to ensure that the feature works correctly and handles edge cases well.