### PR TITLE
Add parameterized test for FlipFlopPredicate class

### DIFF
--- a/src/test/java/com/epam/flipflop/FlipFlopPredicateWhiteBoxAiTest.java
+++ b/src/test/java/com/epam/flipflop/FlipFlopPredicateWhiteBoxAiTest.java
@@ -1,0 +1,48 @@
+package com.epam.flipflop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.function.Predicate;
+
+class FlipFlopPredicateWhiteBoxAiTest {
+    @DisplayName("Evaluates flip-flop predicate:")
+    @ParameterizedTest(name = "[{index}] when state {0}, LHS {1}, RHS {2} it should return {3} and final state is {4}")
+    @CsvSource(delimiter = '|', textBlock =
+            """
+            false | true  | false | true  | true
+            false | true  | true  | true  | false
+            true  | true  | false | true  | true
+            true  | true  | true  | true  | false
+            false | false | false | false | false
+            false | false | true  | false | false
+            true  | false | false | true  | true
+            true  | false | true  | true  | false
+            """
+    )
+    void evaluatesFlipFlopPredicate(
+            boolean initState,
+            boolean lhsOutput,
+            boolean rhsOutput,
+            boolean expectedOutput,
+            boolean expectedState
+    ) {
+        Predicate<Object> lhs = x -> lhsOutput;
+        Predicate<Object> rhs = x -> rhsOutput;
+        var flipFlopPredicate = new FlipFlopPredicate<>(lhs, rhs);
+        flipFlopPredicate.state = initState;
+
+        var actualOutput = flipFlopPredicate.test(null);
+
+        assertThat(actualOutput)
+                .as("When State is %s, LHS Output is %s and RHS Output is %s, then expected output should be %s", initState, lhsOutput, rhsOutput, expectedOutput)
+                .isEqualTo(expectedOutput);
+        
+        assertThat(flipFlopPredicate.state)
+                .as("Final state should be %s", expectedState)
+                .isEqualTo(expectedState);
+    }
+}


### PR DESCRIPTION
Created a new test class FlipFlopPredicateWhiteBoxAiTest.java and added parameterized tests for the FlipFlopPredicate class. It uses different combinations of initial state, left-hand side and right-hand side predicate outputs to test the functionality of the flip-flop predicate. These tests cover various usage scenarios, ensuring the correct behavior of the class under different conditions.