### PR TITLE
Adjust visibility and update tests for AsciiToBinaryConverter

### DIFF
--- a/src/main/java/com/epam/chucknorris/encode/AsciiToBinaryConverter.java
+++ b/src/main/java/com/epam/chucknorris/encode/AsciiToBinaryConverter.java
@@ -4,11 +4,6 @@ import java.util.function.UnaryOperator;
 
 import static java.util.stream.Collectors.joining;
 
-/**
- * A utility class that converts a string to binary representation using ASCII encoding.
- * This class implements the UnaryOperator interface, allowing it to be used as a function
- * to convert a string using the apply method.
- */
 public final class AsciiToBinaryConverter implements UnaryOperator<String> {
     private static final int HIGH_BIT = 0x80;
     private static final int ASCII_MASK = 0x7F;
@@ -20,7 +15,7 @@ public final class AsciiToBinaryConverter implements UnaryOperator<String> {
                 .collect(joining());
     }
 
-    String charToBinary(int value) {
+    private String charToBinary(int value) {
         return Integer.toBinaryString(value & ASCII_MASK | HIGH_BIT).substring(1);
     }
 }

--- a/src/test/java/com/epam/chucknorris/encode/AsciiToBinaryConverterDiffblueTest.java
+++ b/src/test/java/com/epam/chucknorris/encode/AsciiToBinaryConverterDiffblueTest.java
@@ -37,19 +37,4 @@ class AsciiToBinaryConverterDiffblueTest {
         assertEquals("", actualApplyResult);
     }
 
-    /**
-     * Method under test: {@link AsciiToBinaryConverter#charToBinary(int)}
-     */
-    @Test
-    void testCharToBinary() {
-        // Arrange
-        AsciiToBinaryConverter asciiToBinaryConverter = new AsciiToBinaryConverter();
-        int value = 42;
-
-        // Act
-        String actualCharToBinaryResult = asciiToBinaryConverter.charToBinary(value);
-
-        // Assert
-        assertEquals("0101010", actualCharToBinaryResult);
-    }
 }

--- a/src/test/java/com/epam/chucknorris/encode/AsciiToBinaryConverterWhiteBoxAiATest.java
+++ b/src/test/java/com/epam/chucknorris/encode/AsciiToBinaryConverterWhiteBoxAiATest.java
@@ -1,0 +1,25 @@
+package com.epam.chucknorris.encode;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AsciiToBinaryConverterWhiteBoxAiATest {
+
+    @DisplayName("Convert a string to binary using ASCII encoding")
+    @ParameterizedTest(name = "Test case: {0} => ASCII string: {1}, Expected Binary: {2}")
+    @CsvSource(delimiter = '|', textBlock = """
+                Text empty string            | ''  | ''
+                Text lower case alphabets    | abc | 110000111000101100011
+                Text upper case alphabets    | ABC | 100000110000101000011
+                Text numeric values          | 123 | 011000101100100110011
+                Text special characters      | @#$ | 100000001000110100100
+            """)
+    void apply(String scenario, String text, String expectedBinary) {
+        var binaryConverter = new AsciiToBinaryConverter();
+        var actualBinary = binaryConverter.apply(text);
+        assertEquals(expectedBinary, actualBinary);
+    }
+}

--- a/src/test/java/com/epam/chucknorris/encode/AsciiToBinaryConverterWhiteBoxAiBTest.java
+++ b/src/test/java/com/epam/chucknorris/encode/AsciiToBinaryConverterWhiteBoxAiBTest.java
@@ -1,0 +1,32 @@
+package com.epam.chucknorris.encode;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class AsciiToBinaryConverterWhiteBoxAiBTest {
+    private final AsciiToBinaryConverter target = new AsciiToBinaryConverter();
+
+    @DisplayName("Converts to binary string:")
+    @ParameterizedTest(name = "when '{0}' converts to binary, result should be '{1}'")
+    @CsvSource(delimiter = '|', textBlock = """
+            Empty String       |         ''      |   ''
+            Single Character   |         'A'     |   '1000001'
+            Special Character  |         '@'     |   '1000000'
+            Single Digit       |         '4'     |   '0110100'
+            Lower Case letter  |         'a'     |   '1100001'
+            Word               |       'Test'    |   '1010100110010111100111110100'
+            Sentence           | 'Hello, World!' |   '1001000110010111011001101100110111101011000100000101011111011111110010110110011001000100001'
+             """)
+    void convertsToBinaryString(String scenario, String input, String expected) {
+        var actual = target.apply(input);
+
+        assertThat(actual)
+                .as("The result of converting %s to binary should be %s", input, expected)
+                .isEqualTo(expected);
+    }
+
+}

--- a/src/test/java/com/epam/chucknorris/encode/AsciiToBinaryConverterWhiteBoxAiTest.java
+++ b/src/test/java/com/epam/chucknorris/encode/AsciiToBinaryConverterWhiteBoxAiTest.java
@@ -1,39 +1,55 @@
 package com.epam.chucknorris.encode;
 
+import org.assertj.core.api.ThrowableAssert;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("AsciiToBinaryConverter tests - WhiteBoxAiTest")
 class AsciiToBinaryConverterWhiteBoxAiTest {
+    private final AsciiToBinaryConverter converter = new AsciiToBinaryConverter();
 
-    @DisplayName("Convert a string to binary using ASCII encoding")
-    @ParameterizedTest(name = "Test case: {0} => ASCII string: {1}, Expected Binary: {2}")
-    @CsvSource(delimiter = '|', textBlock = """
-                Text empty string            | ''  | ''
-                Text lower case alphabets    | abc | 110000111000101100011
-                Text upper case alphabets    | ABC | 100000110000101000011
-                Text numeric values          | 123 | 011000101100100110011
-                Text special characters      | @#$ | 100000001000110100100
-            """)
-    void apply(String scenario, String text, String expectedBinary) {
-        var binaryConverter = new AsciiToBinaryConverter();
-        var actualBinary = binaryConverter.apply(text);
-        assertEquals(expectedBinary, actualBinary);
+    private static Stream<TestCase> provideTestCases() {
+        return Stream.of(
+                new TestCase("lower case chars", "hello", "11010001100101110110011011001101111"),
+                new TestCase("upper case chars", "HELLO", "10010001000101100110010011001001111"),
+                new TestCase("numeric chars", "1234", "0110001011001001100110110100"),
+                new TestCase("special chars", "!@#$%^", "010000110000000100011010010001001011011110"),
+                new TestCase("space char", " ", "0100000"),
+                new TestCase("empty string", "", ""),
+                new TestCase("mix of chars", "H3llo W@rld!", "100100001100111101100110110011011110100000101011110000001110010110110011001000100001")
+        );
     }
 
-    @DisplayName("Convert a character to binary using ASCII encoding")
-    @ParameterizedTest(name = "Test case: {0} => ASCII character: {1}, Expected Binary: {2}")
-    @CsvSource(delimiter = '|', textBlock = """
-                Character 0                  | 0  | 0000000
-                Character uppercase A        | 65 | 1000001
-                Character lowercase a        | 97 | 1100001
-                Character @                  | 64 | 1000000
-            """)
-    void charToBinary(String scenario, int character, String expectedBinary) {
-        var binaryConverter = new AsciiToBinaryConverter();
-        var actualBinary = binaryConverter.charToBinary(character);
-        assertEquals(expectedBinary, actualBinary);
+    @MethodSource("com.epam.chucknorris.encode.AsciiToBinaryConverterWhiteBoxAiTest#provideTestCases")
+    @ParameterizedTest(name = "[{index}] - {0}")
+    @DisplayName("Should give correct binary conversion")
+    void shouldGiveCorrectBinaryConversion(TestCase testCase) {
+        var result = converter.apply(testCase.input());
+        assertThat(result)
+                .as("The conversion of %s should be %s", testCase.input(), testCase.expectedResult())
+                .isEqualTo(testCase.expectedResult());
+    }
+
+    @Test
+    @DisplayName("Should throw NullPointerException when input is null")
+    void shouldThrowNullPointerExceptionWhenInputIsNull() {
+        ThrowableAssert.ThrowingCallable codeToTest = () -> converter.apply(null);
+        assertThatThrownBy(codeToTest)
+                .as("Calling apply with null should throw NullPointerException")
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    record TestCase(String description, String input, String expectedResult) {
+        @Override
+        public String toString() {
+            return description;
+        }
     }
 }


### PR DESCRIPTION
Changed `charToBinary` method visibility to private in `AsciiToBinaryConverter.java` as it was not intended for public use. Removed respective test case from `AsciiToBinaryConverterDiffblueTest.java`. Comment section was also removed in `AsciiToBinaryConverter.java` as it provided redundant information. Created `AsciiToBinaryConverterWhiteBoxAiBTest.java` and `AsciiToBinaryConverterWhiteBoxAiATest.java` for additional and more comprehensive testing of the class functionalities. Covered different cases to ensure reliable string to binary conversion using ASCII encoding.