### PR TITLE
Add Dice, AbstractDice and related test classes

### DIFF
--- a/src/main/java/com/epam/rockpaperscissors/dice/AbstractDice.java
+++ b/src/main/java/com/epam/rockpaperscissors/dice/AbstractDice.java
@@ -1,0 +1,22 @@
+package com.epam.rockpaperscissors.dice;
+
+import java.util.random.RandomGenerator;
+
+abstract class AbstractDice implements Dice {
+    private final int sides;
+    private final RandomGenerator randomGenerator;
+
+    AbstractDice(int sides, RandomGenerator randomGenerator) {
+        this.sides = sides;
+        this.randomGenerator = randomGenerator;
+    }
+
+    AbstractDice(int sides) {
+        this(sides, RandomGenerator.getDefault());
+    }
+
+    @Override
+    public int roll() {
+        return randomGenerator.nextInt(sides) + 1;
+    }
+}

--- a/src/main/java/com/epam/rockpaperscissors/dice/Dice.java
+++ b/src/main/java/com/epam/rockpaperscissors/dice/Dice.java
@@ -1,0 +1,6 @@
+package com.epam.rockpaperscissors.dice;
+
+@FunctionalInterface
+public interface Dice {
+    int roll();
+}

--- a/src/main/java/com/epam/rockpaperscissors/dice/TrihedralDice.java
+++ b/src/main/java/com/epam/rockpaperscissors/dice/TrihedralDice.java
@@ -1,0 +1,7 @@
+package com.epam.rockpaperscissors.dice;
+
+public final class TrihedralDice extends AbstractDice {
+    public TrihedralDice() {
+        super(3);
+    }
+}

--- a/src/test/java/com/epam/rockpaperscissors/dice/AbstractDiceWhiteBoxAiTest.java
+++ b/src/test/java/com/epam/rockpaperscissors/dice/AbstractDiceWhiteBoxAiTest.java
@@ -1,0 +1,57 @@
+package com.epam.rockpaperscissors.dice;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import java.util.SplittableRandom;
+import java.util.stream.Stream;
+import java.util.random.RandomGenerator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AbstractDiceWhiteBoxAiTest {
+
+    private static final long seed = 1347L;
+    private static final RandomGenerator seededRg = new SplittableRandom(seed);
+
+    static Stream<Object[]> data() { 
+	   var defaultRg = RandomGenerator.getDefault();
+        return Stream.of(
+            new Object[]{"Test with minimum possible sides (1)",
+                         1, defaultRg, 1, 1},
+            new Object[]{"Test with 6 sides (common dice)",
+                         6, defaultRg, 1, 6},
+            new Object[]{"Test with some arbitrary larger number of sides",
+                         100, defaultRg, 1, 100},
+            new Object[]{"Test with a specific seed for SplittableRandom",
+					     10, seededRg, seedGeneratedOutcome(seededRg, 10)[0], seedGeneratedOutcome(seededRg, 10)[1]}
+        );
+    }
+
+   private static int[] seedGeneratedOutcome(RandomGenerator rg, int sides) {
+        int minimum = rg.nextInt(sides) + 1;
+        int maximum = minimum;
+        for (int i = 1; i < 100; i++) {
+            int current = rg.nextInt(sides) + 1;
+            if (current < minimum) {
+                minimum = current;
+            } else if (current > maximum) {
+                maximum = current;
+            }
+        }
+        return new int[] {minimum, maximum};
+    }
+
+    @DisplayName("Rolls dice and verifies the results:")
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("data")
+    void rollsDiceAndVerifies(String scenario, int sides, RandomGenerator rg, int minExpected, int maxExpected) {
+        var dice = new AbstractDice(sides, rg) {};
+
+        var rollResult = dice.roll();
+        assertThat(rollResult)
+            .as("In scenario '%s', the result '%d' should be in the inclusive range [%d, %d]", 
+                 scenario, rollResult, minExpected, maxExpected)
+            .isBetween(minExpected, maxExpected);
+    }
+}

--- a/src/test/java/com/epam/rockpaperscissors/dice/TrihedralDiceWhiteBoxAiTest.java
+++ b/src/test/java/com/epam/rockpaperscissors/dice/TrihedralDiceWhiteBoxAiTest.java
@@ -1,0 +1,20 @@
+package com.epam.rockpaperscissors.dice;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TrihedralDiceWhiteBoxAiTest {
+
+    @DisplayName("Rolls the default Trihedral dice and verifies the results")
+    @Test
+    void testRoll() {
+        var dice = new TrihedralDice();
+        var rollResult = dice.roll();
+
+        assertThat(rollResult)
+                .as("The result '%d' should be in the inclusive range [1, 3]", rollResult)
+                .isBetween(1, 3);
+    }
+}


### PR DESCRIPTION
This commit introduces Dice interface, AbstractDice abstract class, TrihedralDice and their respective test classes. These classes provide the basics for dice functionality for the Rock-Paper-Scissors game. RandomGenerator is used in dice roll implementation for generating random outcome. In test classes, both default and seeded RandomGenerator are used to verify whether dice roll gives values within the expected ranges according to different scenarios.