### PR TITLE
Replace row/column parameters with Dimension in Maze

### DIFF
--- a/src/main/java/exercism/mazymice/Dimension.java
+++ b/src/main/java/exercism/mazymice/Dimension.java
@@ -1,26 +1,26 @@
 package exercism.mazymice;
 
 /**
- * Represents the dimensions of a maze.
+ * Represents the dimensions of a grid.
  * <p>
- * Dimensions of a maze can be represented in cells or characters.
+ * Dimensions of a grid can be represented in cells or characters.
  * Rows and columns are used for cells, while width and height are used for characters.
  */
 @SuppressWarnings("java:S109")
 public record Dimension(int rows, int columns) {
     /**
-     * Returns the width of the maze.
+     * Returns the width of the grid.
      *
-     * @return the width of the maze
+     * @return the width of the grid
      */
     int width() {
         return 2 * columns + 1;
     }
 
     /**
-     * Returns the height of the maze.
+     * Returns the height of the grid.
      *
-     * @return the height of the maze
+     * @return the height of the grid
      */
     int height() {
         return 2 * rows + 1;

--- a/src/main/java/exercism/mazymice/Grid.java
+++ b/src/main/java/exercism/mazymice/Grid.java
@@ -3,24 +3,19 @@ package exercism.mazymice;
 import java.util.BitSet;
 import java.util.EnumSet;
 import java.util.Set;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.random.RandomGenerator;
 
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.IntStream.range;
 
 final class Grid {
-    private final int rows;
-    private final int width;
-    private final int height;
+    private final Dimension dimension;
     private final BitSet grid;
     private final RandomGenerator randomGenerator;
 
-    Grid(int rows, int columns, RandomGenerator randomGenerator) {
-        this.rows = rows;
-        this.width = 2 * columns + 1;
-        this.height = 2 * rows + 1;
-        this.grid = new BitSet(width * height);
+    Grid(Dimension dimension, RandomGenerator randomGenerator) {
+        this.dimension = dimension;
+        this.grid = new BitSet(dimension.width() * dimension.height());
         this.randomGenerator = randomGenerator;
     }
 
@@ -42,8 +37,8 @@ final class Grid {
     }
 
     Grid placeDoors() {
-        new Cell(1 + 2 * random(rows), 0).erase();
-        new Cell(1 + 2 * random(rows), width - 1).erase();
+        new Cell(1 + 2 * random(dimension.rows()), 0).erase();
+        new Cell(1 + 2 * random(dimension.rows()), dimension.width() - 1).erase();
         return this;
     }
 
@@ -63,14 +58,14 @@ final class Grid {
     }
 
     String print() {
-        return range(0, height)
+        return range(0, dimension.height())
                 .mapToObj(this::printLine)
                 .collect(joining());
     }
 
     private StringBuilder printLine(int x) {
-        var sb = new StringBuilder(width + 1);
-        range(0, width)
+        var sb = new StringBuilder(dimension.width() + 1);
+        range(0, dimension.width())
                 .map(y -> new Cell(x, y).symbol())
                 .forEach(sb::appendCodePoint);
         return sb.append(System.lineSeparator());
@@ -86,7 +81,7 @@ final class Grid {
         }
 
         boolean isValid() {
-            return x > 0 && x < height && y > 0 && y < width;
+            return x > 0 && x < dimension.height() && y > 0 && y < dimension.width();
         }
 
         void erase() {
@@ -102,11 +97,11 @@ final class Grid {
         }
 
         int index() {
-            return x * width + y;
+            return x * dimension.width() + y;
         }
 
         boolean isDoor() {
-            return isEmpty() && (y == 0 || y == width - 1);
+            return isEmpty() && (y == 0 || y == dimension.width() - 1);
         }
 
         Cell move(Direction direction) {
@@ -126,8 +121,8 @@ final class Grid {
                 return ' ';
             }
             var n = x > 0 && new Cell(x - 1, y).isNotEmpty() ? 1 : 0;
-            var e = y < width - 1 && new Cell(x, y + 1).isNotEmpty() ? 1 : 0;
-            var s = x < height - 1 && new Cell(x + 1, y).isNotEmpty() ? 1 : 0;
+            var e = y < dimension.width() - 1 && new Cell(x, y + 1).isNotEmpty() ? 1 : 0;
+            var s = x < dimension.height() - 1 && new Cell(x + 1, y).isNotEmpty() ? 1 : 0;
             var w = y > 0 && new Cell(x, y - 1).isNotEmpty() ? 1 : 0;
             var i = n + 2 * e + 4 * s + 8 * w;
             return switch (i) {

--- a/src/main/java/exercism/mazymice/MazeGenerator.java
+++ b/src/main/java/exercism/mazymice/MazeGenerator.java
@@ -6,14 +6,14 @@ import java.util.random.RandomGenerator;
 public final class MazeGenerator {
 
     public String generatePerfectMaze(Dimension dimension) {
-        return new Grid(dimension.rows(), dimension.columns(), RandomGenerator.getDefault())
+        return new Grid(dimension, RandomGenerator.getDefault())
                 .generateMaze()
                 .placeDoors()
                 .print();
     }
 
     public String generatePerfectMaze(Dimension dimension, int seed) {
-        return new Grid(dimension.rows(), dimension.columns(), new Random(seed))
+        return new Grid(dimension, new Random(seed))
                 .generateMaze()
                 .placeDoors()
                 .print();

--- a/src/test/java/exercism/mazymice/Maze.java
+++ b/src/test/java/exercism/mazymice/Maze.java
@@ -1,0 +1,23 @@
+package exercism.mazymice;
+
+import java.util.OptionalInt;
+
+public record Maze(Dimension dimension, char[][] grid, OptionalInt seed) {
+
+    public Maze(Dimension dimension, char[][] maze) {
+        this(dimension, maze, OptionalInt.empty());
+    }
+
+    public Maze(Dimension dimension, char[][] maze, int seed) {
+        this(dimension, maze, OptionalInt.of(seed));
+    }
+
+    String print() {
+        var sb = new StringBuilder();
+        for (var row : grid) {
+            sb.append(row);
+            sb.append(System.lineSeparator());
+        }
+        return sb.toString();
+    }
+}

--- a/src/test/java/exercism/mazymice/MazeGeneratorTest.java
+++ b/src/test/java/exercism/mazymice/MazeGeneratorTest.java
@@ -57,7 +57,7 @@ class MazeGeneratorTest {
                 .isNotEqualTo(maze2);
     }
 
-    @DisplayName("Small square maze with seed 42")
+    @DisplayName("Small square grid with seed 42")
     @ParameterizedTest(name = "Maze with {0} rows and {1} columns should be perfect")
     @CsvSource(textBlock = """
             5, 5, 42
@@ -69,7 +69,7 @@ class MazeGeneratorTest {
         var error = new MazeChecker(dimension, maze).get();
 
         assertThat(error)
-                .as(error.orElse("The maze should be perfect"))
+                .as(error.orElse("The grid should be perfect"))
                 .isEmpty();
 
     }


### PR DESCRIPTION
Replaced direct references to row and column counts with a more descriptive 'Dimension' object in the Grid class. This change simplifies parameters for some Grid methods and provides a more consistent, understandable, and extensible interface for maze (grid) configurations. Updated unit tests to match the new usage, further validating functionality.

closes #43 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Renamed "maze" to "grid" in `Dimension.java` for better clarity.
- New Feature: Updated `Grid.java` to use a `Dimension` object, enhancing code flexibility and readability.
- Refactor: Modified `MazeGenerator.java` to accept a `Dimension` object and an optional seed value, improving the maze generation process.
- New Feature: Introduced a new `Maze` class in `Maze.java` that encapsulates the dimensions, grid, and seed of a maze.
- Test: Updated test case names and assertion messages in `MazeGeneratorTest.java` to reflect the changes made in the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->