### PR TITLE
Add test for single entrance validation in 'MazeGeneratorTest'

### DIFF
--- a/src/test/java/exercism/mazymice/MazeGeneratorTest.java
+++ b/src/test/java/exercism/mazymice/MazeGeneratorTest.java
@@ -104,4 +104,25 @@ class MazeGeneratorTest {
             }
         }
     }
+
+    @Test
+    @DisplayName("The maze has only one entrance on the left side")
+    void theMazeHasOnlyOneEntranceOnTheLeftSide() {
+        var maze = sut.generatePerfectMaze(RECTANGLE);
+        int entranceCount = countEntrances(maze);
+
+        assertThat(entranceCount)
+                .as("The maze has only one entrance on the left side")
+                .isOne();
+    }
+
+    private int countEntrances(char[][] maze) {
+        int entranceCount = 0;
+        for (char[] row : maze) {
+            if (row[0] == '⇨') {
+                entranceCount++;
+            }
+        }
+        return entranceCount;
+    }
 }


### PR DESCRIPTION
This commit adds an additional test in 'MazeGeneratorTest' named 'theMazeHasOnlyOneEntranceOnTheLeftSide'. The purpose of this test is to validate that the generated maze has only one entrance on the left side. A helper function 'countEntrances' has also been added to assist in this test. This ensures that the maze generated adheres to the expected structure and enhances the reliability of the game.

closes #55
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Test: Added a new test case `theMazeHasOnlyOneEntranceOnTheLeftSide()` in the `MazeGeneratorTest` class. This enhancement ensures the reliability of the maze generation algorithm by verifying that each generated maze has exactly one entrance on the left side, improving the consistency and predictability of the game experience for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->