### PR TITLE
Add test for single exit validation in 'MazeGeneratorTest'

### DIFF
--- a/src/test/java/exercism/mazymice/MazeGeneratorTest.java
+++ b/src/test/java/exercism/mazymice/MazeGeneratorTest.java
@@ -116,6 +116,27 @@ class MazeGeneratorTest {
                 .isOne();
     }
 
+    @Test
+    @DisplayName("The maze has a single exit on the right side of the maze")
+    void theMazeHasASingleExitOnTheRightSideOfTheMaze() {
+        var maze = sut.generatePerfectMaze(RECTANGLE);
+        int exitCount = countExits(maze);
+
+        assertThat(exitCount)
+                .as("The maze has a single exit on the right side of the maze")
+                .isOne();
+    }
+
+    private int countExits(char[][] maze) {
+        int exitCount = 0;
+        for (char[] row : maze) {
+            if (row[row.length - 1] == '⇨') {
+                exitCount++;
+            }
+        }
+        return exitCount;
+    }
+
     private int countEntrances(char[][] maze) {
         int entranceCount = 0;
         for (char[] row : maze) {


### PR DESCRIPTION
This commit introduces a new test titled 'theMazeHasASingleExitOnTheRightSideOfTheMaze' to 'MazeGeneratorTest'. The aim of this test is to confirm that the maze generated only comprises a single exit on the right side. A helper method, 'countExits', was also implemented in order to facilitate this test. This ensures stricter adherence to the maze design requirements, thus improving game consistency.

closes #56
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

"Test: Enhanced Maze Generator Test Suite"
- New Feature: Added a test case `theMazeHasASingleExitOnTheRightSideOfTheMaze()` to ensure the maze generation logic consistently produces a maze with a single exit on the right side.
- Refactor: Introduced a helper method `countExits()` to streamline and improve the readability of tests by encapsulating the logic for counting the number of exits in a maze.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->