### PR TITLE
Update Direction enum to include dx, dy properties

### DIFF
--- a/src/main/java/exercism/mazymice/Direction.java
+++ b/src/main/java/exercism/mazymice/Direction.java
@@ -1,5 +1,23 @@
 package exercism.mazymice;
 
 enum Direction {
-    NORTH, EAST, SOUTH, WEST
+    NORTH(0, 1),
+    EAST(1, 0),
+    SOUTH(0, -1),
+    WEST(-1, 0);
+    private final int dx;
+    private final int dy;
+
+    Direction(int dx, int dy) {
+        this.dx = dx;
+        this.dy = dy;
+    }
+
+    public int dx() {
+        return dx;
+    }
+
+    public int dy() {
+        return dy;
+    }
 }

--- a/src/main/java/exercism/mazymice/Grid.java
+++ b/src/main/java/exercism/mazymice/Grid.java
@@ -104,12 +104,7 @@ final class Grid {
         }
 
         Cell move(Direction direction) {
-            return switch (direction) {
-                case NORTH -> new Cell(x, y - 1);
-                case EAST -> new Cell(x + 1, y);
-                case SOUTH -> new Cell(x, y + 1);
-                case WEST -> new Cell(x - 1, y);
-            };
+            return new Cell(x + direction.dx(), y + direction.dy());
         }
 
         char symbol() {

--- a/src/test/java/exercism/mazymice/MazeGeneratorTest.java
+++ b/src/test/java/exercism/mazymice/MazeGeneratorTest.java
@@ -155,18 +155,6 @@ class MazeGeneratorTest {
         }
     }
 
-    private int countPaths(char[][] maze) {
-        int pathCount = 0;
-        for (char[] row : maze) {
-            for (char cell : row) {
-                if (cell == '⇨') {
-                    pathCount++;
-                }
-            }
-        }
-        return pathCount;
-    }
-
     private int countExits(char[][] maze) {
         int exitCount = 0;
         for (char[] row : maze) {

--- a/src/test/java/exercism/mazymice/MazeGeneratorTest.java
+++ b/src/test/java/exercism/mazymice/MazeGeneratorTest.java
@@ -116,6 +116,27 @@ class MazeGeneratorTest {
                 .isOne();
     }
 
+    @Test
+    @DisplayName("The maze has a single exit on the right side of the maze")
+    void theMazeHasASingleExitOnTheRightSideOfTheMaze() {
+        var maze = sut.generatePerfectMaze(RECTANGLE);
+        int exitCount = countExits(maze);
+
+        assertThat(exitCount)
+                .as("The maze has a single exit on the right side of the maze")
+                .isOne();
+    }
+
+    private int countExits(char[][] maze) {
+        int exitCount = 0;
+        for (char[] row : maze) {
+            if (row[row.length - 1] == '⇨') {
+                exitCount++;
+            }
+        }
+        return exitCount;
+    }
+
     private int countEntrances(char[][] maze) {
         int entranceCount = 0;
         for (char[] row : maze) {

--- a/src/test/java/exercism/mazymice/MazeGeneratorTest.java
+++ b/src/test/java/exercism/mazymice/MazeGeneratorTest.java
@@ -10,8 +10,10 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class MazeGeneratorTest {
-    public static final Set<Character> ALLOWED_SYMBOLS = Set.of(
-            ' ', // space
+    private static final char EMPTY_CELL = ' ';
+    private static final char VISITED_CELL = '.';
+    private static final Set<Character> ALLOWED_SYMBOLS = Set.of(
+            EMPTY_CELL, // space
             '┌', // box drawings light down and right
             '─', // box drawings light horizontal
             '┬', // box drawings light down and horizontal
@@ -125,6 +127,44 @@ class MazeGeneratorTest {
         assertThat(exitCount)
                 .as("The maze has a single exit on the right side of the maze")
                 .isOne();
+    }
+
+    @Test
+    @DisplayName("A perfect maze has a single path")
+    void aPerfectMazeHasOnlyOneCorrectPath() {
+        var maze = sut.generatePerfectMaze(RECTANGLE);
+
+        checkPaths(maze, 1, 1);
+    }
+
+    private void checkPaths(char[][] maze, int x, int y) {
+        var isEmptyCell = maze[x][y] == EMPTY_CELL;
+
+        assertThat(isEmptyCell)
+                .as("The maze has only one path")
+                .withFailMessage("an extra passage detected at (%d, %d)", x, y)
+                .isTrue();
+
+        maze[x][y] = VISITED_CELL;
+
+        for (var direction : Direction.values()) {
+            if (maze[x + direction.dx()][y + direction.dy()] == EMPTY_CELL) {
+                maze[x + direction.dx()][y + direction.dy()] = VISITED_CELL;
+                checkPaths(maze, x + 2 * direction.dx(), y + 2 * direction.dy());
+            }
+        }
+    }
+
+    private int countPaths(char[][] maze) {
+        int pathCount = 0;
+        for (char[] row : maze) {
+            for (char cell : row) {
+                if (cell == '⇨') {
+                    pathCount++;
+                }
+            }
+        }
+        return pathCount;
     }
 
     private int countExits(char[][] maze) {


### PR DESCRIPTION
This commit extends the Direction enum to include two properties, dx and dy. These represent possible changes to cell position when moving in a specific direction. The change can simplify movement logic in the Grid class, improving code readability. The additional properties also improve usage versatility for the Direction enum, providing additional context rather than just direction names. Furthermore, a new assert test is added to ensure the generated maze has a single exit and is perfect. 

closes #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Release Notes**

- **Refactor**: Enhanced the `Direction` enum in the `exercism.mazymice` package to include associated values for coordinate changes, improving code readability and reducing duplication.
- **Test**: Added new test cases in `MazeGeneratorTest.java` to ensure that the maze has a single exit on the right side and only one correct path. 
- **Chore**: Introduced private constants `EMPTY_CELL`, `VISITED_CELL` to represent empty and visited cells respectively, increasing code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->