### PR TITLE
Add solution for leetcode problem 338 and corresponding tests

### DIFF
--- a/src/main/java/leetcode/p338/Solution.java
+++ b/src/main/java/leetcode/p338/Solution.java
@@ -1,0 +1,11 @@
+package leetcode.p338;
+
+import java.util.stream.IntStream;
+
+class Solution {
+    public int[] countBits(int n) {
+        return IntStream.rangeClosed(0, n)
+                .map(Integer::bitCount)
+                .toArray();
+    }
+}

--- a/src/test/java/leetcode/p338/SolutionBlackBoxC4Test.java
+++ b/src/test/java/leetcode/p338/SolutionBlackBoxC4Test.java
@@ -1,0 +1,28 @@
+package leetcode.p338;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import java.util.stream.Stream;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SolutionBlackBoxC4Test {
+
+    @DisplayName("countBits tests")
+    @ParameterizedTest(name = "#{index} - Test with n = {0}")
+    @MethodSource("provideTestData")
+    void countBitsTest(int n, int[] expected) {
+        var solution = new Solution();
+        assertThat(solution.countBits(n)).isEqualTo(expected);
+    }
+    
+    private static Stream<Object[]> provideTestData() {
+        return Stream.of(
+                new Object[]{0, new int[]{0}},
+                new Object[]{1, new int[]{0, 1}},
+                new Object[]{2, new int[]{0, 1, 1}},
+                new Object[]{5, new int[]{0, 1, 1, 2, 1, 2}}
+        );
+    }
+
+}


### PR DESCRIPTION
Implemented the 'countBits' method in the Solution.java file for leetcode problem number 338. This method uses the Java 'Integer.bitCount(n)' function to count the number of 1s in the binary representation of a number up to 'n' and return an array of these counts.

Additionally, a test class named 'SolutionBlackBoxC4Test' was added which tests various scenarios including edge cases to ensure the functionality and reliability of the 'countBits' method.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added a new `Solution` class with a `countBits` method. This method takes an integer `n` as input and returns an array of integers representing the count of set bits for each number in the range 0 to `n`.
- Test: Introduced a new test class `SolutionBlackBoxC4Test` that provides comprehensive testing for the `countBits` method, ensuring its correctness across various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->